### PR TITLE
Fixed sending GPS coordinates

### DIFF
--- a/gcphone/html/static/js/app.js
+++ b/gcphone/html/static/js/app.js
@@ -2962,7 +2962,7 @@ webpackJsonp([0], [, , , , , , function(t, e, n) {
                         icons: "fa-undo"
                     }]
                 }).then(function(e) {
-                    "Envoyer Coord GPS" === e.title && t.sendMessage({
+                    "Send GPS Coordinates" === e.title && t.sendMessage({
                         phoneNumber: t.phoneNumber,
                         message: "%pos%"
                     }), t.ignoreControls = !1


### PR DESCRIPTION
Noticed this wasn't working even though I translated it into finnish and apparently if you're translating the code

` onRight: function() {
                var t = this;
                !0 !== this.ignoreControls && -1 === this.selectMessage && (this.ignoreControls = !0, h.a.CreateModal({
                    choix: [{
                        title: "Send GPS Coordinates",
                        icons: "fa-location-arrow"
                    }, {
                        title: "Peruuta",
                        icons: "fa-undo"
                    }]
                }).then(function(e) {
                    "Send GPS Coordinates" === e.title && t.sendMessage({
                        phoneNumber: t.phoneNumber,
                        message: "%pos%"
                    }), t.ignoreControls = !1
                }))
            }
        }),`
Both title: and the function title needs to be the same. This wasn't the case in the plugin.